### PR TITLE
Merge develop

### DIFF
--- a/KubeContext.xcodeproj/project.pbxproj
+++ b/KubeContext.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		83186D3E2043CE0A00968AC2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 83186D3D2043CE0A00968AC2 /* Assets.xcassets */; };
 		83186D412043CE0A00968AC2 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 83186D3F2043CE0A00968AC2 /* MainMenu.xib */; };
 		83186D4A2043CE4A00968AC2 /* StatusMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83186D492043CE4A00968AC2 /* StatusMenuController.swift */; };
+		83423494204E888000AF7BB7 /* PreferencesWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83423492204E888000AF7BB7 /* PreferencesWindow.swift */; };
+		83423495204E888000AF7BB7 /* PreferencesWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 83423493204E888000AF7BB7 /* PreferencesWindow.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -21,6 +23,8 @@
 		83186D422043CE0A00968AC2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		83186D432043CE0A00968AC2 /* KubeContext.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KubeContext.entitlements; sourceTree = "<group>"; };
 		83186D492043CE4A00968AC2 /* StatusMenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusMenuController.swift; sourceTree = "<group>"; };
+		83423492204E888000AF7BB7 /* PreferencesWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesWindow.swift; sourceTree = "<group>"; };
+		83423493204E888000AF7BB7 /* PreferencesWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PreferencesWindow.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -57,6 +61,8 @@
 				83186D492043CE4A00968AC2 /* StatusMenuController.swift */,
 				83186D3D2043CE0A00968AC2 /* Assets.xcassets */,
 				83186D3F2043CE0A00968AC2 /* MainMenu.xib */,
+				83423492204E888000AF7BB7 /* PreferencesWindow.swift */,
+				83423493204E888000AF7BB7 /* PreferencesWindow.xib */,
 				83186D422043CE0A00968AC2 /* Info.plist */,
 				83186D432043CE0A00968AC2 /* KubeContext.entitlements */,
 			);
@@ -123,6 +129,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				83186D3E2043CE0A00968AC2 /* Assets.xcassets in Resources */,
+				83423495204E888000AF7BB7 /* PreferencesWindow.xib in Resources */,
 				83186D412043CE0A00968AC2 /* MainMenu.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -135,6 +142,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				83186D4A2043CE4A00968AC2 /* StatusMenuController.swift in Sources */,
+				83423494204E888000AF7BB7 /* PreferencesWindow.swift in Sources */,
 				83186D3C2043CE0A00968AC2 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/KubeContext/Base.lproj/MainMenu.xib
+++ b/KubeContext/Base.lproj/MainMenu.xib
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
     </dependencies>
     <objects>

--- a/KubeContext/PreferencesWindow.swift
+++ b/KubeContext/PreferencesWindow.swift
@@ -22,17 +22,59 @@ class PreferencesWindow: NSWindowController, NSWindowDelegate {
     return NSNib.Name("PreferencesWindow")
   }
 
+  func preferenceStateValue(_ action: String = "read", _ state: Bool = true) -> Bool? {
+    // set variables to read/write files
+    let homeDirectory = FileManager.default.homeDirectoryForCurrentUser
+    let preferencesDirURL = homeDirectory.appendingPathComponent(".config/kubecontext")
+    let preferencesFileURL = preferencesDirURL.appendingPathComponent("config")
+    // set variables to check if config directory exists
+    let fileManager = FileManager.default
+    var isDir : ObjCBool = true
+    // check if directory exists, if not create it and a default config file
+    if fileManager.fileExists(atPath: String(describing: preferencesDirURL.path), isDirectory:&isDir) != true {
+      try! fileManager.createDirectory(atPath: String(describing: preferencesDirURL.path), withIntermediateDirectories: true, attributes: nil)
+      let data = ("contextInMenu=true").data(using: String.Encoding.utf8)
+      fileManager.createFile(atPath: String(describing: preferencesFileURL.path), contents: data, attributes: nil)
+    }
+    if action == "read" {
+      let config = try! String(contentsOf: preferencesFileURL)
+      if config.contains("contextInMenu=true") {
+        return true
+      } else {
+        return false
+      }
+    }
+    if action == "write" {
+      let contents = "contextInMenu=" + String(describing: state)
+      try! contents.write(to: preferencesFileURL, atomically: false, encoding: String.Encoding.utf8)
+      return true
+    }
+    // This should never fire because of default parameters
+    return true
+  }
+
   override func windowDidLoad() {
-      super.windowDidLoad()
-      self.window?.center()
-      self.window?.makeKeyAndOrderFront(nil)
-      NSApp.activate(ignoringOtherApps: true)
+    if preferenceStateValue("read", true)! {
+      showContextInMenuBar.state = NSControl.StateValue.on
+    } else {
+      showContextInMenuBar.state = NSControl.StateValue.off
+    }
+    super.windowDidLoad()
+    self.window?.center()
+    self.window?.makeKeyAndOrderFront(nil)
+    self.window?.level = .floating
+    NSApp.activate(ignoringOtherApps: true)
   }
 
   func windowWillClose(_ notification: Notification) {
-    let defaults = UserDefaults.standard
-    defaults.set(showContextInMenuBar.state.rawValue, forKey: "showContextInMenuBar")
+    if showContextInMenuBar.state.rawValue == 0 {
+      preferenceStateValue("write", false)
+    } else {
+      if showContextInMenuBar.state.rawValue == 1 {
+        preferenceStateValue("write", true)
+      }
+    }
     delegate?.preferencesDidUpdate()
   }
-    
+  
 }

--- a/KubeContext/PreferencesWindow.swift
+++ b/KubeContext/PreferencesWindow.swift
@@ -1,0 +1,38 @@
+//
+//  PreferencesWindow.swift
+//  KubeContext
+//
+//  Created by Jeremy Shapiro on 3/6/18.
+//  Copyright © 2018 Jeremy Shapiro. All rights reserved.
+//
+
+import Cocoa
+
+protocol PreferencesWindowDelegate {
+  func preferencesDidUpdate()
+}
+
+var delegate: PreferencesWindowDelegate?
+
+class PreferencesWindow: NSWindowController, NSWindowDelegate {
+  
+  @IBOutlet weak var showContextInMenuBar: NSButton!
+  
+  override var windowNibName: NSNib.Name? {
+    return NSNib.Name("PreferencesWindow")
+  }
+
+  override func windowDidLoad() {
+      super.windowDidLoad()
+      self.window?.center()
+      self.window?.makeKeyAndOrderFront(nil)
+      NSApp.activate(ignoringOtherApps: true)
+  }
+
+  func windowWillClose(_ notification: Notification) {
+    let defaults = UserDefaults.standard
+    defaults.set(showContextInMenuBar.state.rawValue, forKey: "showContextInMenuBar")
+    delegate?.preferencesDidUpdate()
+  }
+    
+}

--- a/KubeContext/PreferencesWindow.xib
+++ b/KubeContext/PreferencesWindow.xib
@@ -13,17 +13,17 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="KubeContext Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" animationBehavior="default" titlebarAppearsTransparent="YES" id="F0z-JX-Cv5" userLabel="Preferences">
-            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
+        <window title="KubeContext Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5" userLabel="Preferences">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" fullSizeContentView="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="300" height="100"/>
+            <rect key="contentRect" x="196" y="240" width="351" height="233"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1178"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="300" height="100"/>
+                <rect key="frame" x="0.0" y="0.0" width="351" height="233"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MQh-bn-cDx">
-                        <rect key="frame" x="55" y="43" width="190" height="25"/>
+                        <rect key="frame" x="80" y="23" width="190" height="25"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Show Context In Menu Bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="WaX-JY-lc1">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -33,12 +33,29 @@ IA
 </string>
                         </buttonCell>
                     </button>
+                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="scO-pF-UlT">
+                        <rect key="frame" x="125" y="95" width="100" height="100"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AppIcon" id="Z6O-Jn-VIl"/>
+                    </imageView>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DmB-cN-Tc7">
+                        <rect key="frame" x="133" y="68" width="83" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="KubeContext" id="s45-ZR-EAf">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
                 </subviews>
             </view>
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
             </connections>
-            <point key="canvasLocation" x="44" y="71"/>
+            <point key="canvasLocation" x="18.5" y="90.5"/>
         </window>
     </objects>
+    <resources>
+        <image name="AppIcon" width="128" height="128"/>
+    </resources>
 </document>

--- a/KubeContext/PreferencesWindow.xib
+++ b/KubeContext/PreferencesWindow.xib
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="PreferencesWindow" customModule="KubeContext" customModuleProvider="target">
+            <connections>
+                <outlet property="showContextInMenuBar" destination="MQh-bn-cDx" id="hMR-fz-ZWj"/>
+                <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="KubeContext Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" animationBehavior="default" titlebarAppearsTransparent="YES" id="F0z-JX-Cv5" userLabel="Preferences">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="196" y="240" width="300" height="100"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1178"/>
+            <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
+                <rect key="frame" x="0.0" y="0.0" width="300" height="100"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MQh-bn-cDx">
+                        <rect key="frame" x="55" y="43" width="190" height="25"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Show Context In Menu Bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="WaX-JY-lc1">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+IA
+</string>
+                        </buttonCell>
+                    </button>
+                </subviews>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
+            </connections>
+            <point key="canvasLocation" x="44" y="71"/>
+        </window>
+    </objects>
+</document>

--- a/KubeContext/StatusMenuController.swift
+++ b/KubeContext/StatusMenuController.swift
@@ -58,10 +58,19 @@ class StatusMenuController: NSObject, PreferencesWindowDelegate {
   @objc func indicateCurrentContext() {
     for item in (statusItem.menu?.items)! {
       if item.title == currentContext() {
-        //item.onStateImage = #imageLiteral(resourceName: "circle_green")
         item.state = NSControl.StateValue.on
-        // if preference button is selected to show context in menubar then uncomment next line.
-        statusItem.title = " " + item.title
+        // Read defaults to determine to show context name in
+        // Refactor into function to call and return bool
+        for (key, value) in UserDefaults.standard.dictionaryRepresentation() {
+          if key == "showContextInMenuBar" {
+            let contextInMenuBarPreference = value as! NSNumber
+            if contextInMenuBarPreference == 1 as NSNumber{
+              statusItem.title = " " + item.title
+            } else {
+              statusItem.title = ""
+            }
+          }
+        }
       } else {
         item.state = NSControl.StateValue.off
       }
@@ -124,7 +133,12 @@ class StatusMenuController: NSObject, PreferencesWindowDelegate {
   
   override func awakeFromNib() {
     preferencesWindow = PreferencesWindow()
-    //preferencesWindowDelegate = self
+    // Sets default of showing context in menu at run
+    // Refactor to set config file that stores prefs and read from that
+    let defaults = UserDefaults.standard
+    if !defaults.dictionaryRepresentation().keys.contains("showContextInMenuBar") {
+      defaults.set(1, forKey: "showContextInMenuBar")
+    }
     constructMenu()
     // Check and menuitem of current context if changed outside of app (e.g. cli)
     let timer = Timer.scheduledTimer(timeInterval: 0.8, target: self, selector: #selector(indicateCurrentContext), userInfo: nil, repeats: true)

--- a/KubeContext/StatusMenuController.swift
+++ b/KubeContext/StatusMenuController.swift
@@ -8,22 +8,26 @@
 
 import Cocoa
 
-class StatusMenuController: NSObject {
+class StatusMenuController: NSObject, PreferencesWindowDelegate {
   
-  // @IBOutlet weak var statusMenu: NSMenu!
   let statusMenu = NSMenu()
   let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+  var preferencesWindow: PreferencesWindow!
   
   func constructMenu() {
     // Set Icon
     let icon = NSImage(named: NSImage.Name(rawValue: "statusIcon"))
     icon?.isTemplate = false // "true" is best for dark mode
     statusItem.image = icon
-    // Build current context item
-    let menuItem = NSMenuItem()
-    menuItem.title = "Current Context: " + currentContext()
-    menuItem.action = nil
-    statusMenu.addItem(menuItem)
+    // Build refresh item
+    let refreshItem = NSMenuItem(title: "Refresh Contexts", action: #selector(StatusMenuController.refreshAll(_:)), keyEquivalent: "r")
+    refreshItem.target = self
+    statusMenu.addItem(refreshItem)
+    statusMenu.addItem(NSMenuItem.separator())
+    // Build preferences window
+    let preferencesItem = NSMenuItem(title: "Preferences", action: #selector(StatusMenuController.preferencesClicked(_:)), keyEquivalent: "p")
+    preferencesItem.target = self
+    statusMenu.addItem(preferencesItem)
     // Build list of remaining contexts
     statusMenu.addItem(NSMenuItem.separator())
     // Call function to list contexts and save in dictionary
@@ -40,6 +44,28 @@ class StatusMenuController: NSObject {
     statusMenu.addItem(NSMenuItem(title: "Quit KubeContext", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
     // Write menu
     statusItem.menu = statusMenu
+    // Add checkmark next to current context
+    indicateCurrentContext()
+  }
+  
+  @objc func refreshAll(_ sender: NSMenuItem?) {
+    // Re-contstruct menu; use-case is when you add new contexts
+    // and need to make them appear in the menu
+    statusMenu.removeAllItems()
+    constructMenu()
+  }
+  
+  @objc func indicateCurrentContext() {
+    for item in (statusItem.menu?.items)! {
+      if item.title == currentContext() {
+        //item.onStateImage = #imageLiteral(resourceName: "circle_green")
+        item.state = NSControl.StateValue.on
+        // if preference button is selected to show context in menubar then uncomment next line.
+        statusItem.title = " " + item.title
+      } else {
+        item.state = NSControl.StateValue.off
+      }
+    }
   }
   
   @objc func setContext(_ sender: NSMenuItem) {
@@ -48,8 +74,7 @@ class StatusMenuController: NSObject {
     let setContext = "current-context: " + currentContext()
     let updatedConfig = kubeConfig!.1.replacingOccurrences(of: setContext, with: savedContext)
     try! updatedConfig.write(to: kubeConfig!.2, atomically: false, encoding: String.Encoding.utf8)
-    statusMenu.removeAllItems()
-    constructMenu()
+    indicateCurrentContext()
   }
   
   func currentContext() -> String {
@@ -67,7 +92,6 @@ class StatusMenuController: NSObject {
     let kubeConfigSplit = setKubeConfig()!.0
     // Initialize array
     var everyContext = [String]()
-    
     for (index, value) in kubeConfigSplit.enumerated() {
       if value.range(of:"- context:") != nil {
         let contextLine = index + 3
@@ -90,8 +114,21 @@ class StatusMenuController: NSObject {
     return (splitConfig, config, fileURL)
   }
   
+  @objc func preferencesClicked(_ sender: Any) {
+    preferencesWindow.showWindow(nil)
+  }
+  
+  func preferencesDidUpdate() {
+    refreshAll(nil)
+  }
+  
   override func awakeFromNib() {
+    preferencesWindow = PreferencesWindow()
+    //preferencesWindowDelegate = self
     constructMenu()
+    // Check and menuitem of current context if changed outside of app (e.g. cli)
+    let timer = Timer.scheduledTimer(timeInterval: 0.8, target: self, selector: #selector(indicateCurrentContext), userInfo: nil, repeats: true)
+    timer.fire()
   }
 }
 


### PR DESCRIPTION
- Indicate current context in dropdown with checkmark
- Add reload button to allow reloading from kube config when contexts are created, updated or deleted
- Add preferences menu with option to add current context name to menubar
- Persist preference setting in file at ~/.config/kubecontext/config